### PR TITLE
Basic tracking features

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,25 +11,21 @@ SimpleSegment allows for manual control of when and how the events are sent to S
 ## Status
 
 ### Implemented
-*Nothing yet :)*
-
-### Planned
-
-The plan is to be an drop in replacement for the official gem, so all the APIs will stay the same whenever possible.
-
-```ruby
-analytics = SimpleSegment::Client.new({
-  write_key: 'YOUR_WRITE_KEY'
-})
-```
 
 - `analytics.track(...)`
 - `analytics.identify(...)`
 - `analytics.group(...)`
 - `analytics.page(...)`
 - `analytics.alias(...)`
-- `analytics.flush` - no op for backwards compatibility with the official gem
+- `analytics.flush` (no op for backwards compatibility with the official gem)
+
+### Planned
+
 - Ability to manually batch events, https://segment.com/docs/libraries/http/#import
+- Configurable network error handling
+- Configurable logging
+
+The plan is to be an drop in replacement for the official gem, so all the APIs will stay the same whenever possible.
 
 ## Installation
 
@@ -49,7 +45,26 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+Create a client instance:
+
+```ruby
+analytics = SimpleSegment::Client.new({
+  write_key: 'YOUR_WRITE_KEY'
+})
+```
+
+Use it as you would use `analytics-ruby`:
+
+```ruby
+analytics.track(
+  {
+    user_id: user.id,
+    event: 'Created Account'
+  }
+)
+```
+
+If you find inconsistencies with `analytics-ruby` feel free to file an issue.
 
 ## Development
 

--- a/lib/simple_segment.rb
+++ b/lib/simple_segment.rb
@@ -1,5 +1,7 @@
-require "simple_segment/version"
+require 'net/http'
+require 'json'
+require 'simple_segment/version'
+require 'simple_segment/client'
 
 module SimpleSegment
-  # Your code goes here...
 end

--- a/lib/simple_segment/client.rb
+++ b/lib/simple_segment/client.rb
@@ -70,5 +70,9 @@ module SimpleSegment
     def alias(options)
       Operations::Alias.new(symbolize_keys(options), config).call
     end
+
+    # A no op, added for backwards compatibility with `analytics-ruby`
+    def flush
+    end
   end
 end

--- a/lib/simple_segment/client.rb
+++ b/lib/simple_segment/client.rb
@@ -1,11 +1,15 @@
+require 'simple_segment/utils'
+require 'simple_segment/configuration'
 require 'simple_segment/request'
 
 module SimpleSegment
   class Client
-    attr_reader :write_key
+    include SimpleSegment::Utils
+
+    attr_reader :config
 
     def initialize(options = {})
-      @write_key = options.fetch(:write_key)
+      @config = Configuration.new(options)
     end
 
     # @param [Hash] options
@@ -17,7 +21,7 @@ module SimpleSegment
     # @option :timestamp [#iso8601] (Time.now)
     def identify(options)
       payload = build_identify_payload(options)
-      Request.new('/v1/identify', write_key: write_key).post(payload)
+      Request.new('/v1/identify', config).post(payload)
     end
 
     # @param [Hash] options
@@ -30,7 +34,7 @@ module SimpleSegment
     # @option :timestamp [#iso8601] (Time.now)
     def track(options)
       payload = build_track_payload(options)
-      Request.new('/v1/track', write_key: write_key).post(payload)
+      Request.new('/v1/track', config).post(payload)
     end
 
     # @param [Hash] options
@@ -43,7 +47,7 @@ module SimpleSegment
     # @option :timestamp [#iso8601] (Time.now)
     def page(options)
       payload = build_page_payload(options)
-      Request.new('/v1/page', write_key: write_key).post(payload)
+      Request.new('/v1/page', config).post(payload)
     end
 
     # @param [Hash] options
@@ -56,7 +60,7 @@ module SimpleSegment
     # @option :timestamp [#iso8601] (Time.now)
     def group(options)
       payload = build_group_payload(options)
-      Request.new('/v1/group', write_key: write_key).post(payload)
+      Request.new('/v1/group', config).post(payload)
     end
 
     # @param [Hash] options
@@ -69,7 +73,7 @@ module SimpleSegment
     # @option :timestamp [#iso8601] (Time.now)
     def alias(options)
       payload = build_alias_payload(options)
-      Request.new('/v1/alias', write_key: write_key).post(payload)
+      Request.new('/v1/alias', config).post(payload)
     end
 
     private
@@ -163,10 +167,6 @@ module SimpleSegment
         timestamp: options.fetch(:timestamp, current_time).iso8601,
         sentAt: current_time.iso8601
       }
-    end
-
-    def symbolize_keys(hash)
-      hash.each_with_object({}) { |(key, value), result| result[key.to_sym] = value }
     end
   end
 end

--- a/lib/simple_segment/client.rb
+++ b/lib/simple_segment/client.rb
@@ -1,0 +1,172 @@
+require 'simple_segment/request'
+
+module SimpleSegment
+  class Client
+    attr_reader :write_key
+
+    def initialize(options = {})
+      @write_key = options.fetch(:write_key)
+    end
+
+    # @param [Hash] options
+    # @option :user_id
+    # @option :anonymous_id
+    # @option :traits [Hash]
+    # @option :context [Hash]
+    # @option :integrations [Hash]
+    # @option :timestamp [#iso8601] (Time.now)
+    def identify(options)
+      payload = build_identify_payload(options)
+      Request.new('/v1/identify', write_key: write_key).post(payload)
+    end
+
+    # @param [Hash] options
+    # @option :event [String] required
+    # @option :user_id
+    # @option :anonymous_id
+    # @option :properties [Hash]
+    # @option :context [Hash]
+    # @option :integrations [Hash]
+    # @option :timestamp [#iso8601] (Time.now)
+    def track(options)
+      payload = build_track_payload(options)
+      Request.new('/v1/track', write_key: write_key).post(payload)
+    end
+
+    # @param [Hash] options
+    # @option :user_id
+    # @option :anonymous_id
+    # @option :name [String]
+    # @option :properties [Hash]
+    # @option :context [Hash]
+    # @option :integrations [Hash]
+    # @option :timestamp [#iso8601] (Time.now)
+    def page(options)
+      payload = build_page_payload(options)
+      Request.new('/v1/page', write_key: write_key).post(payload)
+    end
+
+    # @param [Hash] options
+    # @option :user_id
+    # @option :anonymous_id
+    # @option :group_id required
+    # @option :traits [Hash]
+    # @option :context [Hash]
+    # @option :integrations [Hash]
+    # @option :timestamp [#iso8601] (Time.now)
+    def group(options)
+      payload = build_group_payload(options)
+      Request.new('/v1/group', write_key: write_key).post(payload)
+    end
+
+    # @param [Hash] options
+    # @option :user_id
+    # @option :anonymous_id
+    # @option :previous_id required
+    # @option :traits [Hash]
+    # @option :context [Hash]
+    # @option :integrations [Hash]
+    # @option :timestamp [#iso8601] (Time.now)
+    def alias(options)
+      payload = build_alias_payload(options)
+      Request.new('/v1/alias', write_key: write_key).post(payload)
+    end
+
+    private
+
+    def build_identify_payload(hash, current_time = Time.now)
+      options = symbolize_keys(hash)
+      if options[:user_id].nil? && options[:anonymous_id].nil?
+        raise ArgumentError, 'user_id or anonymous_id must be present'
+      end
+
+      {
+        userId: options[:user_id],
+        anonymousId: options[:anonymous_id],
+        traits: options[:traits],
+        context: options[:context],
+        integrations: options[:integrations],
+        timestamp: options.fetch(:timestamp, current_time).iso8601,
+        sentAt: current_time.iso8601
+      }
+    end
+
+    def build_track_payload(hash, current_time = Time.now)
+      options = symbolize_keys(hash)
+      event = options.fetch(:event) { raise ArgumentError, 'event name must be present' }
+      if options[:user_id].nil? && options[:anonymous_id].nil?
+        raise ArgumentError, 'user_id or anonymous_id must be present'
+      end
+
+      {
+        event: event,
+        userId: options[:user_id],
+        anonymousId: options[:anonymous_id],
+        properties: options[:properties],
+        context: options[:context],
+        integrations: options[:integrations],
+        timestamp: options.fetch(:timestamp, current_time).iso8601,
+        sentAt: current_time.iso8601
+      }
+    end
+
+    def build_page_payload(hash, current_time = Time.now)
+      options = symbolize_keys(hash)
+      if options[:user_id].nil? && options[:anonymous_id].nil?
+        raise ArgumentError, 'user_id or anonymous_id must be present'
+      end
+
+      {
+        userId: options[:user_id],
+        anonymousId: options[:anonymous_id],
+        name: options[:name],
+        properties: options[:properties],
+        context: options[:context],
+        integrations: options[:integrations],
+        timestamp: options.fetch(:timestamp, current_time).iso8601,
+        sentAt: current_time.iso8601
+      }
+    end
+
+    def build_group_payload(hash, current_time = Time.now)
+      options = symbolize_keys(hash)
+      group_id = options.fetch(:group_id) { raise ArgumentError, 'group_id must be present' }
+      if options[:user_id].nil? && options[:anonymous_id].nil?
+        raise ArgumentError, 'user_id or anonymous_id must be present'
+      end
+
+      {
+        userId: options[:user_id],
+        anonymousId: options[:anonymous_id],
+        groupId: group_id,
+        traits: options[:traits],
+        context: options[:context],
+        integrations: options[:integrations],
+        timestamp: options.fetch(:timestamp, current_time).iso8601,
+        sentAt: current_time.iso8601
+      }
+    end
+
+    def build_alias_payload(hash, current_time = Time.now)
+      options = symbolize_keys(hash)
+      previous_id = options.fetch(:previous_id) { raise ArgumentError, 'previous_id must be present' }
+      if options[:user_id].nil? && options[:anonymous_id].nil?
+        raise ArgumentError, 'user_id or anonymous_id must be present'
+      end
+
+      {
+        userId: options[:user_id],
+        anonymousId: options[:anonymous_id],
+        previousId: previous_id,
+        context: options[:context],
+        integrations: options[:integrations],
+        timestamp: options.fetch(:timestamp, current_time).iso8601,
+        sentAt: current_time.iso8601
+      }
+    end
+
+    def symbolize_keys(hash)
+      hash.each_with_object({}) { |(key, value), result| result[key.to_sym] = value }
+    end
+  end
+end

--- a/lib/simple_segment/client.rb
+++ b/lib/simple_segment/client.rb
@@ -1,6 +1,6 @@
 require 'simple_segment/utils'
 require 'simple_segment/configuration'
-require 'simple_segment/request'
+require 'simple_segment/operations'
 
 module SimpleSegment
   class Client
@@ -20,8 +20,7 @@ module SimpleSegment
     # @option :integrations [Hash]
     # @option :timestamp [#iso8601] (Time.now)
     def identify(options)
-      payload = build_identify_payload(options)
-      Request.new('/v1/identify', config).post(payload)
+      Operations::Identify.new(symbolize_keys(options), config).call
     end
 
     # @param [Hash] options
@@ -33,8 +32,7 @@ module SimpleSegment
     # @option :integrations [Hash]
     # @option :timestamp [#iso8601] (Time.now)
     def track(options)
-      payload = build_track_payload(options)
-      Request.new('/v1/track', config).post(payload)
+      Operations::Track.new(symbolize_keys(options), config).call
     end
 
     # @param [Hash] options
@@ -46,8 +44,7 @@ module SimpleSegment
     # @option :integrations [Hash]
     # @option :timestamp [#iso8601] (Time.now)
     def page(options)
-      payload = build_page_payload(options)
-      Request.new('/v1/page', config).post(payload)
+      Operations::Page.new(symbolize_keys(options), config).call
     end
 
     # @param [Hash] options
@@ -59,8 +56,7 @@ module SimpleSegment
     # @option :integrations [Hash]
     # @option :timestamp [#iso8601] (Time.now)
     def group(options)
-      payload = build_group_payload(options)
-      Request.new('/v1/group', config).post(payload)
+      Operations::Group.new(symbolize_keys(options), config).call
     end
 
     # @param [Hash] options
@@ -72,101 +68,7 @@ module SimpleSegment
     # @option :integrations [Hash]
     # @option :timestamp [#iso8601] (Time.now)
     def alias(options)
-      payload = build_alias_payload(options)
-      Request.new('/v1/alias', config).post(payload)
-    end
-
-    private
-
-    def build_identify_payload(hash, current_time = Time.now)
-      options = symbolize_keys(hash)
-      if options[:user_id].nil? && options[:anonymous_id].nil?
-        raise ArgumentError, 'user_id or anonymous_id must be present'
-      end
-
-      {
-        userId: options[:user_id],
-        anonymousId: options[:anonymous_id],
-        traits: options[:traits],
-        context: options[:context],
-        integrations: options[:integrations],
-        timestamp: options.fetch(:timestamp, current_time).iso8601,
-        sentAt: current_time.iso8601
-      }
-    end
-
-    def build_track_payload(hash, current_time = Time.now)
-      options = symbolize_keys(hash)
-      event = options.fetch(:event) { raise ArgumentError, 'event name must be present' }
-      if options[:user_id].nil? && options[:anonymous_id].nil?
-        raise ArgumentError, 'user_id or anonymous_id must be present'
-      end
-
-      {
-        event: event,
-        userId: options[:user_id],
-        anonymousId: options[:anonymous_id],
-        properties: options[:properties],
-        context: options[:context],
-        integrations: options[:integrations],
-        timestamp: options.fetch(:timestamp, current_time).iso8601,
-        sentAt: current_time.iso8601
-      }
-    end
-
-    def build_page_payload(hash, current_time = Time.now)
-      options = symbolize_keys(hash)
-      if options[:user_id].nil? && options[:anonymous_id].nil?
-        raise ArgumentError, 'user_id or anonymous_id must be present'
-      end
-
-      {
-        userId: options[:user_id],
-        anonymousId: options[:anonymous_id],
-        name: options[:name],
-        properties: options[:properties],
-        context: options[:context],
-        integrations: options[:integrations],
-        timestamp: options.fetch(:timestamp, current_time).iso8601,
-        sentAt: current_time.iso8601
-      }
-    end
-
-    def build_group_payload(hash, current_time = Time.now)
-      options = symbolize_keys(hash)
-      group_id = options.fetch(:group_id) { raise ArgumentError, 'group_id must be present' }
-      if options[:user_id].nil? && options[:anonymous_id].nil?
-        raise ArgumentError, 'user_id or anonymous_id must be present'
-      end
-
-      {
-        userId: options[:user_id],
-        anonymousId: options[:anonymous_id],
-        groupId: group_id,
-        traits: options[:traits],
-        context: options[:context],
-        integrations: options[:integrations],
-        timestamp: options.fetch(:timestamp, current_time).iso8601,
-        sentAt: current_time.iso8601
-      }
-    end
-
-    def build_alias_payload(hash, current_time = Time.now)
-      options = symbolize_keys(hash)
-      previous_id = options.fetch(:previous_id) { raise ArgumentError, 'previous_id must be present' }
-      if options[:user_id].nil? && options[:anonymous_id].nil?
-        raise ArgumentError, 'user_id or anonymous_id must be present'
-      end
-
-      {
-        userId: options[:user_id],
-        anonymousId: options[:anonymous_id],
-        previousId: previous_id,
-        context: options[:context],
-        integrations: options[:integrations],
-        timestamp: options.fetch(:timestamp, current_time).iso8601,
-        sentAt: current_time.iso8601
-      }
+      Operations::Alias.new(symbolize_keys(options), config).call
     end
   end
 end

--- a/lib/simple_segment/configuration.rb
+++ b/lib/simple_segment/configuration.rb
@@ -1,0 +1,13 @@
+module SimpleSegment
+  class Configuration
+    include SimpleSegment::Utils
+
+    attr_reader :write_key
+
+    def initialize(settings = {})
+      symbolized_settings = symbolize_keys(settings)
+      @write_key = symbolized_settings[:write_key]
+      raise ArgumentError, 'Missing required option :write_key' unless @write_key
+    end
+  end
+end

--- a/lib/simple_segment/operations.rb
+++ b/lib/simple_segment/operations.rb
@@ -1,0 +1,12 @@
+require 'simple_segment/request'
+require 'simple_segment/operations/operation'
+require 'simple_segment/operations/identify'
+require 'simple_segment/operations/track'
+require 'simple_segment/operations/page'
+require 'simple_segment/operations/group'
+require 'simple_segment/operations/alias'
+
+module SimpleSegment
+  module Operations
+  end
+end

--- a/lib/simple_segment/operations/alias.rb
+++ b/lib/simple_segment/operations/alias.rb
@@ -7,19 +7,12 @@ module SimpleSegment
 
       private
 
-      def build_payload(current_time = Time.now)
-        check_identity!
+      def build_payload
         raise ArgumentError, 'previous_id must be present' unless options[:previous_id]
 
-        {
-          userId: options[:user_id],
-          anonymousId: options[:anonymous_id],
-          previousId: options[:previous_id],
-          context: options[:context],
-          integrations: options[:integrations],
-          timestamp: options.fetch(:timestamp, current_time).iso8601,
-          sentAt: current_time.iso8601
-        }
+        base_payload.merge({
+          previousId: options[:previous_id]
+        })
       end
     end
   end

--- a/lib/simple_segment/operations/alias.rb
+++ b/lib/simple_segment/operations/alias.rb
@@ -1,0 +1,26 @@
+module SimpleSegment
+  module Operations
+    class Alias < Operation
+      def call
+        Request.new('/v1/alias', config).post(build_payload)
+      end
+
+      private
+
+      def build_payload(current_time = Time.now)
+        check_identity!
+        raise ArgumentError, 'previous_id must be present' unless options[:previous_id]
+
+        {
+          userId: options[:user_id],
+          anonymousId: options[:anonymous_id],
+          previousId: options[:previous_id],
+          context: options[:context],
+          integrations: options[:integrations],
+          timestamp: options.fetch(:timestamp, current_time).iso8601,
+          sentAt: current_time.iso8601
+        }
+      end
+    end
+  end
+end

--- a/lib/simple_segment/operations/group.rb
+++ b/lib/simple_segment/operations/group.rb
@@ -7,20 +7,13 @@ module SimpleSegment
 
       private
 
-      def build_payload(current_time = Time.now)
-        check_identity!
+      def build_payload
         raise ArgumentError, 'group_id must be present' unless options[:group_id]
 
-        {
-          userId: options[:user_id],
-          anonymousId: options[:anonymous_id],
-          groupId: options[:group_id],
+        base_payload.merge({
           traits: options[:traits],
-          context: options[:context],
-          integrations: options[:integrations],
-          timestamp: options.fetch(:timestamp, current_time).iso8601,
-          sentAt: current_time.iso8601
-        }
+          groupId: options[:group_id]
+        })
       end
     end
   end

--- a/lib/simple_segment/operations/group.rb
+++ b/lib/simple_segment/operations/group.rb
@@ -1,0 +1,27 @@
+module SimpleSegment
+  module Operations
+    class Group < Operation
+      def call
+        Request.new('/v1/group', config).post(build_payload)
+      end
+
+      private
+
+      def build_payload(current_time = Time.now)
+        check_identity!
+        raise ArgumentError, 'group_id must be present' unless options[:group_id]
+
+        {
+          userId: options[:user_id],
+          anonymousId: options[:anonymous_id],
+          groupId: options[:group_id],
+          traits: options[:traits],
+          context: options[:context],
+          integrations: options[:integrations],
+          timestamp: options.fetch(:timestamp, current_time).iso8601,
+          sentAt: current_time.iso8601
+        }
+      end
+    end
+  end
+end

--- a/lib/simple_segment/operations/identify.rb
+++ b/lib/simple_segment/operations/identify.rb
@@ -1,0 +1,25 @@
+module SimpleSegment
+  module Operations
+    class Identify < Operation
+      def call
+        Request.new('/v1/identify', config).post(build_payload)
+      end
+
+      private
+
+      def build_payload(current_time = Time.now)
+        check_identity!
+
+        {
+          userId: options[:user_id],
+          anonymousId: options[:anonymous_id],
+          traits: options[:traits],
+          context: options[:context],
+          integrations: options[:integrations],
+          timestamp: options.fetch(:timestamp, current_time).iso8601,
+          sentAt: current_time.iso8601
+        }
+      end
+    end
+  end
+end

--- a/lib/simple_segment/operations/identify.rb
+++ b/lib/simple_segment/operations/identify.rb
@@ -7,18 +7,10 @@ module SimpleSegment
 
       private
 
-      def build_payload(current_time = Time.now)
-        check_identity!
-
-        {
-          userId: options[:user_id],
-          anonymousId: options[:anonymous_id],
-          traits: options[:traits],
-          context: options[:context],
-          integrations: options[:integrations],
-          timestamp: options.fetch(:timestamp, current_time).iso8601,
-          sentAt: current_time.iso8601
-        }
+      def build_payload
+        base_payload.merge({
+          traits: options[:traits]
+        })
       end
     end
   end

--- a/lib/simple_segment/operations/operation.rb
+++ b/lib/simple_segment/operations/operation.rb
@@ -1,6 +1,13 @@
 module SimpleSegment
   module Operations
     class Operation
+      DEFAULT_CONTEXT = {
+        library: {
+          name: 'simple_segment',
+          version: SimpleSegment::VERSION
+        }
+      }.freeze
+
       attr_reader :options, :config
 
       def initialize(options = {}, config)
@@ -13,6 +20,20 @@ module SimpleSegment
       end
 
       private
+
+      def base_payload
+        check_identity!
+        current_time = Time.now
+
+        {
+          userId: options[:user_id],
+          anonymousId: options[:anonymous_id],
+          context: DEFAULT_CONTEXT.merge(options[:context].to_h),
+          integrations: options[:integrations],
+          timestamp: options.fetch(:timestamp, current_time).iso8601,
+          sentAt: current_time.iso8601
+        }
+      end
 
       def check_identity!
         unless options[:user_id] || options[:anonymous_id]

--- a/lib/simple_segment/operations/operation.rb
+++ b/lib/simple_segment/operations/operation.rb
@@ -1,0 +1,24 @@
+module SimpleSegment
+  module Operations
+    class Operation
+      attr_reader :options, :config
+
+      def initialize(options = {}, config)
+        @options = options
+        @config = config
+      end
+
+      def call
+        raise 'Must be implemented in a subclass'
+      end
+
+      private
+
+      def check_identity!
+        unless options[:user_id] || options[:anonymous_id]
+          raise ArgumentError, 'user_id or anonymous_id must be present'
+        end
+      end
+    end
+  end
+end

--- a/lib/simple_segment/operations/page.rb
+++ b/lib/simple_segment/operations/page.rb
@@ -1,0 +1,26 @@
+module SimpleSegment
+  module Operations
+    class Page < Operation
+      def call
+        Request.new('/v1/page', config).post(build_payload)
+      end
+
+      private
+
+      def build_payload(current_time = Time.now)
+        check_identity!
+
+        {
+          userId: options[:user_id],
+          anonymousId: options[:anonymous_id],
+          name: options[:name],
+          properties: options[:properties],
+          context: options[:context],
+          integrations: options[:integrations],
+          timestamp: options.fetch(:timestamp, current_time).iso8601,
+          sentAt: current_time.iso8601
+        }
+      end
+    end
+  end
+end

--- a/lib/simple_segment/operations/page.rb
+++ b/lib/simple_segment/operations/page.rb
@@ -7,19 +7,11 @@ module SimpleSegment
 
       private
 
-      def build_payload(current_time = Time.now)
-        check_identity!
-
-        {
-          userId: options[:user_id],
-          anonymousId: options[:anonymous_id],
+      def build_payload
+        base_payload.merge({
           name: options[:name],
-          properties: options[:properties],
-          context: options[:context],
-          integrations: options[:integrations],
-          timestamp: options.fetch(:timestamp, current_time).iso8601,
-          sentAt: current_time.iso8601
-        }
+          properties: options[:properties]
+        })
       end
     end
   end

--- a/lib/simple_segment/operations/track.rb
+++ b/lib/simple_segment/operations/track.rb
@@ -8,19 +8,12 @@ module SimpleSegment
       private
 
       def build_payload(current_time = Time.now)
-        check_identity!
         raise ArgumentError, 'event name must be present' unless options[:event]
 
-        {
+        base_payload.merge({
           event: options[:event],
-          userId: options[:user_id],
-          anonymousId: options[:anonymous_id],
-          properties: options[:properties],
-          context: options[:context],
-          integrations: options[:integrations],
-          timestamp: options.fetch(:timestamp, current_time).iso8601,
-          sentAt: current_time.iso8601
-        }
+          properties: options[:properties]
+        })
       end
     end
   end

--- a/lib/simple_segment/operations/track.rb
+++ b/lib/simple_segment/operations/track.rb
@@ -1,0 +1,27 @@
+module SimpleSegment
+  module Operations
+    class Track < Operation
+      def call
+        Request.new('/v1/track', config).post(build_payload)
+      end
+
+      private
+
+      def build_payload(current_time = Time.now)
+        check_identity!
+        raise ArgumentError, 'event name must be present' unless options[:event]
+
+        {
+          event: options[:event],
+          userId: options[:user_id],
+          anonymousId: options[:anonymous_id],
+          properties: options[:properties],
+          context: options[:context],
+          integrations: options[:integrations],
+          timestamp: options.fetch(:timestamp, current_time).iso8601,
+          sentAt: current_time.iso8601
+        }
+      end
+    end
+  end
+end

--- a/lib/simple_segment/request.rb
+++ b/lib/simple_segment/request.rb
@@ -6,15 +6,14 @@ module SimpleSegment
       'accept' => 'application/json'
     }.freeze
 
-    attr_reader :path, :headers, :write_key
+    attr_reader :path, :write_key
 
-    def initialize(path, write_key:, headers: DEFAULT_HEADERS)
+    def initialize(path, config)
       @path = path
-      @headers = headers
-      @write_key = write_key
+      @write_key = config.write_key
     end
 
-    def post(payload = {})
+    def post(payload, headers: DEFAULT_HEADERS)
       uri = URI(BASE_URL)
       Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
         payload = JSON.generate(payload)

--- a/lib/simple_segment/request.rb
+++ b/lib/simple_segment/request.rb
@@ -1,0 +1,28 @@
+module SimpleSegment
+  class Request
+    BASE_URL = 'https://api.segment.io'.freeze
+    DEFAULT_HEADERS = {
+      'Content-Type' => 'application/json',
+      'accept' => 'application/json'
+    }.freeze
+
+    attr_reader :path, :headers, :write_key
+
+    def initialize(path, write_key:, headers: DEFAULT_HEADERS)
+      @path = path
+      @headers = headers
+      @write_key = write_key
+    end
+
+    def post(payload = {})
+      uri = URI(BASE_URL)
+      Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+        payload = JSON.generate(payload)
+        request = Net::HTTP::Post.new(path, headers)
+        request.basic_auth write_key, nil
+
+        http.request(request, payload)
+      end
+    end
+  end
+end

--- a/lib/simple_segment/utils.rb
+++ b/lib/simple_segment/utils.rb
@@ -1,0 +1,9 @@
+module SimpleSegment
+  module Utils
+    def symbolize_keys(hash)
+      hash.each_with_object({}) { |(key, value), result|
+        result[key.to_sym] = value
+      }
+    end
+  end
+end

--- a/lib/simple_segment/version.rb
+++ b/lib/simple_segment/version.rb
@@ -1,3 +1,3 @@
 module SimpleSegment
-  VERSION = "0.1.0"
+  VERSION = '0.1.0.pre'
 end

--- a/simple_segment.gemspec
+++ b/simple_segment.gemspec
@@ -22,4 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "webmock", "~> 1.24"
+  spec.add_development_dependency "timecop", "~> 0.8.0"
 end

--- a/spec/simple_segment/client_spec.rb
+++ b/spec/simple_segment/client_spec.rb
@@ -7,7 +7,7 @@ describe SimpleSegment::Client do
 
   describe '#identify' do
     it 'sends identity and properties to segment' do
-      now = Time.new(2017,1,1)
+      now = Time.new(2999,12,29)
       options = {
         user_id: 'id',
         traits: {
@@ -66,7 +66,7 @@ describe SimpleSegment::Client do
 
   describe '#track' do
     it 'sends event and properties to segment' do
-      now = Time.new(2017,1,1)
+      now = Time.new(2999,12,29)
       options = {
         event: 'Delivered Package',
         user_id: 'id',
@@ -131,7 +131,7 @@ describe SimpleSegment::Client do
 
   describe '#page' do
     it 'sends page info to segment' do
-      now = Time.new(2017,1,1)
+      now = Time.new(2999,12,29)
       options = {
         user_id: 'id',
         name: 'Zoidberg',
@@ -190,7 +190,7 @@ describe SimpleSegment::Client do
 
   describe '#group' do
     it 'sends group info to segment' do
-      now = Time.new(2017,1,1)
+      now = Time.new(2999,12,29)
       options = {
         user_id: 'id',
         group_id: 'group_id',
@@ -253,7 +253,7 @@ describe SimpleSegment::Client do
 
   describe '#alias' do
     it 'sends alias info to segment' do
-      now = Time.new(2017,1,1)
+      now = Time.new(2999,12,29)
       options = {
         user_id: 'id',
         previous_id: 'previous_id',

--- a/spec/simple_segment/client_spec.rb
+++ b/spec/simple_segment/client_spec.rb
@@ -1,0 +1,310 @@
+require 'spec_helper'
+
+describe SimpleSegment::Client do
+  subject(:client) {
+    described_class.new(write_key: 'WRITE_KEY')
+  }
+
+  describe '#identify' do
+    it 'sends identity and properties to segment' do
+      now = Time.new(2017,1,1)
+      options = {
+        user_id: 'id',
+        traits: {
+          name: 'Philip J. Fry',
+          occupation: 'Delivery Boy'
+        },
+        context: {
+          employer: 'Planet Express'
+        },
+        integrations: {
+          all: true
+        },
+        timestamp: Time.new(2016,3,23)
+      }
+      expected_request_body = {
+        'userId' => 'id',
+        'anonymousId' => nil,
+        'traits' => {
+          'name' => 'Philip J. Fry',
+          'occupation' => 'Delivery Boy'
+        },
+        'context' => {
+          'employer' => 'Planet Express'
+        },
+        'integrations' => {
+          'all' => true
+        },
+        'timestamp' => Time.new(2016,3,23).iso8601,
+        'sentAt' => now.iso8601
+      }
+      request_stub = stub_request(:post, 'https://WRITE_KEY:@api.segment.io/v1/identify').
+        with(body: expected_request_body)
+
+      Timecop.freeze(now) do
+        client.identify(options)
+        expect(request_stub).to have_been_requested.once
+      end
+    end
+
+    context 'input checks' do
+      before(:example) {
+        stub_request(:post, 'https://WRITE_KEY:@api.segment.io/v1/identify')
+      }
+
+      it 'errors with user_id and anonymous_id blank' do
+        expect { client.identify }.to raise_error(ArgumentError)
+      end
+
+      it 'allows blank user_id if anonymous_id is present' do
+        expect {
+          client.identify(anonymous_id: 'id')
+        }.not_to raise_error
+      end
+    end
+  end
+
+  describe '#track' do
+    it 'sends event and properties to segment' do
+      now = Time.new(2017,1,1)
+      options = {
+        event: 'Delivered Package',
+        user_id: 'id',
+        properties: {
+          contents: 'Lug nuts',
+          delivery_to: 'Robots of Chapek 9'
+        },
+        context: {
+          crew: %w(Bender Fry Leela)
+        },
+        integrations: {
+          all: true
+        },
+        timestamp: Time.new(2016,3,23)
+      }
+      expected_request_body = {
+        'event' => 'Delivered Package',
+        'userId' => 'id',
+        'anonymousId' => nil,
+        'properties' => {
+          'contents' => 'Lug nuts',
+          'delivery_to' => 'Robots of Chapek 9'
+        },
+        'context' => {
+          'crew' => %w(Bender Fry Leela)
+        },
+        'integrations' => {
+          'all' => true
+        },
+        'timestamp' => Time.new(2016,3,23).iso8601,
+        'sentAt' => now.iso8601
+      }
+      request_stub = stub_request(:post, 'https://WRITE_KEY:@api.segment.io/v1/track').
+        with(body: expected_request_body)
+
+      Timecop.freeze(now) do
+        client.track(options)
+        expect(request_stub).to have_been_requested.once
+      end
+    end
+
+    context 'input checks' do
+      before(:example) {
+        stub_request(:post, 'https://WRITE_KEY:@api.segment.io/v1/track')
+      }
+
+      it 'errors without an event name' do
+        expect { client.track(user_id: 'id') }.to raise_error(ArgumentError)
+      end
+
+      it 'errors with user_id and anonymous_id blank' do
+        expect { client.track(event: 'test') }.to raise_error(ArgumentError)
+      end
+
+      it 'allows blank user_id if anonymous_id is present' do
+        expect {
+          client.track(event: 'test', anonymous_id: 'id')
+        }.not_to raise_error
+      end
+    end
+  end
+
+  describe '#page' do
+    it 'sends page info to segment' do
+      now = Time.new(2017,1,1)
+      options = {
+        user_id: 'id',
+        name: 'Zoidberg',
+        properties: {
+          url: 'https://en.wikipedia.org/wiki/Zoidberg'
+        },
+        context: {
+          company: 'Planet Express'
+        },
+        integrations: {
+          all: true
+        },
+        timestamp: Time.new(2016,3,23)
+      }
+      expected_request_body = {
+        'userId' => 'id',
+        'anonymousId' => nil,
+        'name' => 'Zoidberg',
+        'properties' => {
+          'url' => 'https://en.wikipedia.org/wiki/Zoidberg'
+        },
+        'context' => {
+          'company' => 'Planet Express'
+        },
+        'integrations' => {
+          'all' => true
+        },
+        'timestamp' => Time.new(2016,3,23).iso8601,
+        'sentAt' => now.iso8601
+      }
+      request_stub = stub_request(:post, 'https://WRITE_KEY:@api.segment.io/v1/page').
+        with(body: expected_request_body)
+
+      Timecop.freeze(now) do
+        client.page(options)
+        expect(request_stub).to have_been_requested.once
+      end
+    end
+
+    context 'input checks' do
+      before(:example) {
+        stub_request(:post, 'https://WRITE_KEY:@api.segment.io/v1/page')
+      }
+
+      it 'errors with user_id and anonymous_id blank' do
+        expect { client.page }.to raise_error(ArgumentError)
+      end
+
+      it 'allows blank user_id if anonymous_id is present' do
+        expect {
+          client.page(anonymous_id: 'id')
+        }.not_to raise_error
+      end
+    end
+  end
+
+  describe '#group' do
+    it 'sends group info to segment' do
+      now = Time.new(2017,1,1)
+      options = {
+        user_id: 'id',
+        group_id: 'group_id',
+        traits: {
+          name: 'Planet Express'
+        },
+        context: {
+          locale: 'AL1'
+        },
+        integrations: {
+          all: true
+        },
+        timestamp: Time.new(2016,3,23)
+      }
+      expected_request_body = {
+        'userId' => 'id',
+        'anonymousId' => nil,
+        'groupId' => 'group_id',
+        'traits' => {
+          'name' => 'Planet Express'
+        },
+        'context' => {
+          'locale' => 'AL1'
+        },
+        'integrations' => {
+          'all' => true
+        },
+        'timestamp' => Time.new(2016,3,23).iso8601,
+        'sentAt' => now.iso8601
+      }
+      request_stub = stub_request(:post, 'https://WRITE_KEY:@api.segment.io/v1/group').
+        with(body: expected_request_body)
+
+      Timecop.freeze(now) do
+        client.group(options)
+        expect(request_stub).to have_been_requested.once
+      end
+    end
+
+    context 'input checks' do
+      before(:example) {
+        stub_request(:post, 'https://WRITE_KEY:@api.segment.io/v1/group')
+      }
+
+      it 'errors without a group id' do
+        expect { client.group(user_id: 'id') }.to raise_error(ArgumentError)
+      end
+
+      it 'errors with user_id and anonymous_id blank' do
+        expect { client.group(group_id: 'id') }.to raise_error(ArgumentError)
+      end
+
+      it 'allows blank user_id if anonymous_id is present' do
+        expect {
+          client.group(group_id: 'id', anonymous_id: 'id')
+        }.not_to raise_error
+      end
+    end
+  end
+
+  describe '#alias' do
+    it 'sends alias info to segment' do
+      now = Time.new(2017,1,1)
+      options = {
+        user_id: 'id',
+        previous_id: 'previous_id',
+        context: {
+          locale: 'AL1'
+        },
+        integrations: {
+          all: true
+        },
+        timestamp: Time.new(2016,3,23)
+      }
+      expected_request_body = {
+        'userId' => 'id',
+        'anonymousId' => nil,
+        'previousId' => 'previous_id',
+        'context' => {
+          'locale' => 'AL1'
+        },
+        'integrations' => {
+          'all' => true
+        },
+        'timestamp' => Time.new(2016,3,23).iso8601,
+        'sentAt' => now.iso8601
+      }
+      request_stub = stub_request(:post, 'https://WRITE_KEY:@api.segment.io/v1/alias').
+        with(body: expected_request_body)
+
+      Timecop.freeze(now) do
+        client.alias(options)
+        expect(request_stub).to have_been_requested.once
+      end
+    end
+
+    context 'input checks' do
+      before(:example) {
+        stub_request(:post, 'https://WRITE_KEY:@api.segment.io/v1/alias')
+      }
+
+      it 'errors without a previous id' do
+        expect { client.alias(user_id: 'id') }.to raise_error(ArgumentError)
+      end
+
+      it 'errors with user_id and anonymous_id blank' do
+        expect { client.alias(previous_id: 'id') }.to raise_error(ArgumentError)
+      end
+
+      it 'allows blank user_id if anonymous_id is present' do
+        expect {
+          client.alias(previous_id: 'id', anonymous_id: 'id')
+        }.not_to raise_error
+      end
+    end
+  end
+end

--- a/spec/simple_segment/client_spec.rb
+++ b/spec/simple_segment/client_spec.rb
@@ -30,7 +30,11 @@ describe SimpleSegment::Client do
           'occupation' => 'Delivery Boy'
         },
         'context' => {
-          'employer' => 'Planet Express'
+          'employer' => 'Planet Express',
+          'library' => {
+            'name' => 'simple_segment',
+            'version' => SimpleSegment::VERSION
+          }
         },
         'integrations' => {
           'all' => true
@@ -91,7 +95,11 @@ describe SimpleSegment::Client do
           'delivery_to' => 'Robots of Chapek 9'
         },
         'context' => {
-          'crew' => %w(Bender Fry Leela)
+          'crew' => %w(Bender Fry Leela),
+          'library' => {
+            'name' => 'simple_segment',
+            'version' => SimpleSegment::VERSION
+          }
         },
         'integrations' => {
           'all' => true
@@ -154,7 +162,11 @@ describe SimpleSegment::Client do
           'url' => 'https://en.wikipedia.org/wiki/Zoidberg'
         },
         'context' => {
-          'company' => 'Planet Express'
+          'company' => 'Planet Express',
+          'library' => {
+            'name' => 'simple_segment',
+            'version' => SimpleSegment::VERSION
+          }
         },
         'integrations' => {
           'all' => true
@@ -213,7 +225,11 @@ describe SimpleSegment::Client do
           'name' => 'Planet Express'
         },
         'context' => {
-          'locale' => 'AL1'
+          'locale' => 'AL1',
+          'library' => {
+            'name' => 'simple_segment',
+            'version' => SimpleSegment::VERSION
+          }
         },
         'integrations' => {
           'all' => true
@@ -270,7 +286,11 @@ describe SimpleSegment::Client do
         'anonymousId' => nil,
         'previousId' => 'previous_id',
         'context' => {
-          'locale' => 'AL1'
+          'locale' => 'AL1',
+          'library' => {
+            'name' => 'simple_segment',
+            'version' => SimpleSegment::VERSION
+          }
         },
         'integrations' => {
           'all' => true

--- a/spec/simple_segment/client_spec.rb
+++ b/spec/simple_segment/client_spec.rb
@@ -307,4 +307,10 @@ describe SimpleSegment::Client do
       end
     end
   end
+
+  describe '#flush' do
+    it 'does not blow up' do
+      expect { client.flush }.not_to raise_error
+    end
+  end
 end

--- a/spec/simple_segment/configuration_spec.rb
+++ b/spec/simple_segment/configuration_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe SimpleSegment::Configuration do
+  it 'requires a write_key' do
+    expect {
+      described_class.new(write_key: nil)
+    }.to raise_error(ArgumentError)
+  end
+
+  it 'works with symbol keys' do
+    config = described_class.new(write_key: 'test')
+    expect(config.write_key).to eq ('test')
+  end
+
+  it 'works with string keys' do
+    config = described_class.new('write_key' => 'key')
+    expect(config.write_key).to eq ('key')
+  end
+end

--- a/spec/simple_segment_spec.rb
+++ b/spec/simple_segment_spec.rb
@@ -4,8 +4,4 @@ describe SimpleSegment do
   it 'has a version number' do
     expect(SimpleSegment::VERSION).not_to be nil
   end
-
-  it 'does something useful' do
-    expect(false).to eq(true)
-  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,6 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'simple_segment'
+require 'webmock/rspec'
+require 'timecop'
+
+WebMock.disable_net_connect!


### PR DESCRIPTION
This PR implements the following operations (see details on the future roadmap in the readme):

- `track`
- `identify`
- `group`
- `page`
- `alias`
- `flush` (no op for backwards compatibility with the official gem)

Might have gone a little overboard with extracting classes, but we'll see :smile: 