### PR TITLE
Serializing batches

### DIFF
--- a/lib/simple_segment/batch.rb
+++ b/lib/simple_segment/batch.rb
@@ -2,11 +2,11 @@ module SimpleSegment
   class Batch
     include SimpleSegment::Utils
 
-    attr_reader :config, :payload
+    attr_reader :client, :payload
     attr_accessor :context, :integrations
 
-    def initialize(config)
-      @config = config
+    def initialize(client)
+      @client = client
       @payload = { batch: [] }
       @context = {}
       @integrations = {}
@@ -35,13 +35,13 @@ module SimpleSegment
       payload[:context] = context
       payload[:integrations] = integrations
 
-      Request.new('/v1/import', config).post(payload)
+      Request.new(client).post('/v1/import', payload)
     end
 
     private
 
     def add(operation_class, options, action)
-      operation = operation_class.new(symbolize_keys(options), config)
+      operation = operation_class.new(client, symbolize_keys(options))
       operation_payload = operation.build_payload
       operation_payload[:action] = action
       payload[:batch] << operation_payload

--- a/lib/simple_segment/client.rb
+++ b/lib/simple_segment/client.rb
@@ -21,7 +21,7 @@ module SimpleSegment
     # @option :integrations [Hash]
     # @option :timestamp [#iso8601] (Time.now)
     def identify(options)
-      Operations::Identify.new(symbolize_keys(options), config).call
+      Operations::Identify.new(self, symbolize_keys(options)).call
     end
 
     # @param [Hash] options
@@ -33,7 +33,7 @@ module SimpleSegment
     # @option :integrations [Hash]
     # @option :timestamp [#iso8601] (Time.now)
     def track(options)
-      Operations::Track.new(symbolize_keys(options), config).call
+      Operations::Track.new(self, symbolize_keys(options)).call
     end
 
     # @param [Hash] options
@@ -45,7 +45,7 @@ module SimpleSegment
     # @option :integrations [Hash]
     # @option :timestamp [#iso8601] (Time.now)
     def page(options)
-      Operations::Page.new(symbolize_keys(options), config).call
+      Operations::Page.new(self, symbolize_keys(options)).call
     end
 
     # @param [Hash] options
@@ -57,7 +57,7 @@ module SimpleSegment
     # @option :integrations [Hash]
     # @option :timestamp [#iso8601] (Time.now)
     def group(options)
-      Operations::Group.new(symbolize_keys(options), config).call
+      Operations::Group.new(self, symbolize_keys(options)).call
     end
 
     # @param [Hash] options
@@ -69,11 +69,11 @@ module SimpleSegment
     # @option :integrations [Hash]
     # @option :timestamp [#iso8601] (Time.now)
     def alias(options)
-      Operations::Alias.new(symbolize_keys(options), config).call
+      Operations::Alias.new(self, symbolize_keys(options)).call
     end
 
     def batch
-      batch = Batch.new(config)
+      batch = Batch.new(self)
       yield(batch)
       batch.commit
     end

--- a/lib/simple_segment/client.rb
+++ b/lib/simple_segment/client.rb
@@ -72,6 +72,15 @@ module SimpleSegment
       Operations::Alias.new(self, symbolize_keys(options)).call
     end
 
+    # @yield [batch] Yields a special batch object that can be used to group
+    #                `identify`, `track`, `page` and `group` calls into a
+    #                single API request.
+    # @example
+    #   client.batch do |analytics|
+    #     analytics.context = { 'foo' => 'bar' }
+    #     analytics.identify(user_id: 'id')
+    #     analytics.track(event: 'Delivered Package', user_id: 'id')
+    #   end
     def batch
       batch = Batch.new(self)
       yield(batch)

--- a/lib/simple_segment/operations/alias.rb
+++ b/lib/simple_segment/operations/alias.rb
@@ -2,7 +2,7 @@ module SimpleSegment
   module Operations
     class Alias < Operation
       def call
-        Request.new('/v1/alias', config).post(build_payload)
+        request.post('/v1/alias', build_payload)
       end
 
       def build_payload

--- a/lib/simple_segment/operations/group.rb
+++ b/lib/simple_segment/operations/group.rb
@@ -2,7 +2,7 @@ module SimpleSegment
   module Operations
     class Group < Operation
       def call
-        Request.new('/v1/group', config).post(build_payload)
+        request.post('/v1/group', build_payload)
       end
 
       def build_payload

--- a/lib/simple_segment/operations/identify.rb
+++ b/lib/simple_segment/operations/identify.rb
@@ -2,7 +2,7 @@ module SimpleSegment
   module Operations
     class Identify < Operation
       def call
-        Request.new('/v1/identify', config).post(build_payload)
+        request.post('/v1/identify', build_payload)
       end
 
       def build_payload

--- a/lib/simple_segment/operations/operation.rb
+++ b/lib/simple_segment/operations/operation.rb
@@ -8,11 +8,11 @@ module SimpleSegment
         }
       }.freeze
 
-      attr_reader :options, :config
+      attr_reader :options, :request
 
-      def initialize(options = {}, config)
+      def initialize(client, options = {})
         @options = options
-        @config = config
+        @request = Request.new(client)
       end
 
       def call

--- a/lib/simple_segment/operations/page.rb
+++ b/lib/simple_segment/operations/page.rb
@@ -2,7 +2,7 @@ module SimpleSegment
   module Operations
     class Page < Operation
       def call
-        Request.new('/v1/page', config).post(build_payload)
+        request.post('/v1/page', build_payload)
       end
 
       def build_payload

--- a/lib/simple_segment/operations/track.rb
+++ b/lib/simple_segment/operations/track.rb
@@ -2,7 +2,7 @@ module SimpleSegment
   module Operations
     class Track < Operation
       def call
-        Request.new('/v1/track', config).post(build_payload)
+        request.post('/v1/track', build_payload)
       end
 
       def build_payload

--- a/lib/simple_segment/request.rb
+++ b/lib/simple_segment/request.rb
@@ -6,15 +6,14 @@ module SimpleSegment
       'accept' => 'application/json'
     }.freeze
 
-    attr_reader :path, :write_key, :error_handler
+    attr_reader :write_key, :error_handler
 
-    def initialize(path, config)
-      @path = path
-      @write_key = config.write_key
-      @error_handler = config.on_error
+    def initialize(client)
+      @write_key = client.config.write_key
+      @error_handler = client.config.on_error
     end
 
-    def post(payload, headers: DEFAULT_HEADERS)
+    def post(path, payload, headers: DEFAULT_HEADERS)
       response, status_code, response_body = nil, nil, nil
       uri = URI(BASE_URL)
       payload = JSON.generate(payload)

--- a/lib/simple_segment/utils.rb
+++ b/lib/simple_segment/utils.rb
@@ -1,5 +1,9 @@
 module SimpleSegment
   module Utils
+    def self.included(klass)
+      klass.extend(self)
+    end
+
     def symbolize_keys(hash)
       hash.each_with_object({}) { |(key, value), result|
         result[key.to_sym] = value

--- a/spec/simple_segment/batch_spec.rb
+++ b/spec/simple_segment/batch_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe SimpleSegment::Batch do
-  let(:config) { SimpleSegment::Configuration.new(write_key: 'key') }
+  let(:client) { SimpleSegment::Client.new(write_key: 'key') }
 
   it 'supports identify, group, track and page' do
     request_stub = stub_request(:post, 'https://key:@api.segment.io/v1/import').
@@ -10,7 +10,7 @@ describe SimpleSegment::Batch do
         batch.map { |operation| operation['action'] } == %w(identify group track page)
       }
 
-    batch = described_class.new(config)
+    batch = described_class.new(client)
     batch.identify(user_id: 'id')
     batch.group(user_id: 'id', group_id: 'group_id')
     batch.track(event: 'Delivered Package', user_id: 'id')
@@ -28,7 +28,7 @@ describe SimpleSegment::Batch do
         context == expected_context
       }
 
-    batch = described_class.new(config)
+    batch = described_class.new(client)
     batch.context = expected_context
     batch.track(event: 'Delivered Package', user_id: 'id')
     batch.commit
@@ -44,7 +44,7 @@ describe SimpleSegment::Batch do
         integrations == expected_integrations
       }
 
-    batch = described_class.new(config)
+    batch = described_class.new(client)
     batch.integrations = expected_integrations
     batch.track(event: 'Delivered Package', user_id: 'id')
     batch.commit
@@ -53,7 +53,7 @@ describe SimpleSegment::Batch do
   end
 
   it 'validates event payload' do
-    batch = described_class.new(config)
+    batch = described_class.new(client)
 
     expect {
       batch.track(event: nil)
@@ -61,7 +61,7 @@ describe SimpleSegment::Batch do
   end
 
   it 'errors when trying to commit an empty batch' do
-    batch = described_class.new(config)
+    batch = described_class.new(client)
 
     expect {
       batch.commit

--- a/spec/simple_segment/request_spec.rb
+++ b/spec/simple_segment/request_spec.rb
@@ -7,10 +7,10 @@ describe SimpleSegment::Request do
         to_return(status: 500, body: { error: 'Does not compute' }.to_json)
     }
 
-    it 'does not raise an error with default config' do
-      config = SimpleSegment::Configuration.new(write_key: 'key')
+    it 'does not raise an error with default client' do
+      client = SimpleSegment::Client.new(write_key: 'key')
       expect {
-        described_class.new('/v1/track', config).post({})
+        described_class.new(client).post('/v1/track', {})
       }.not_to raise_error
     end
 
@@ -22,11 +22,11 @@ describe SimpleSegment::Request do
         response = res
         exception = e
       }
-      config = SimpleSegment::Configuration.new(
+      client = SimpleSegment::Client.new(
         write_key: 'key',
         on_error: error_handler
       )
-      described_class.new('/v1/track', config).post({})
+      described_class.new(client).post('/v1/track', {})
 
       expect(error_code).to eq('500')
       expect(error_body).to eq({ error: 'Does not compute' }.to_json)


### PR DESCRIPTION
#### Overview
Adds ability to serialize/desirialize batches, this can be used to process them in a background job system:

```ruby
    batch = SimpleSegment::Batch.new(client)
    batch.identify(user_id: 'philip_j_fry')
    batch.track(event: 'Delivered Package', user_id: 'philip_j_fry')
    serialized_batch = batch.serialize

    # Later in a background worker
    SimpleSegment::Batch.deserialize(client, serialized_batch).commit
```

Also refactors internal objects a bit so it's easier to use them directly (like in this Batch example).