### PR TITLE
[NEW] Added Stub and Logger option

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,28 @@ analytics.batch do |batch|
 end
 ```
 
+### Stub API calls
+
+You can stub your API calls avoiding unecessary calls in development and automated test environments.
+Backwards compatibility with the official gem
+
+```ruby
+analytics = SimpleSegment::Client.new(
+  write_key: 'YOUR_WRITE_KEY', # required
+  stub: true
+)
+```
+
+### Configurable Logger
+If you don't set a logger Ruby Logger class will be used as default.
+
+```ruby
+analytics = SimpleSegment::Client.new(
+  write_key: 'YOUR_WRITE_KEY', # required
+  logger: Rails.logger
+)
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/simple_segment/configuration.rb
+++ b/lib/simple_segment/configuration.rb
@@ -1,13 +1,18 @@
+require 'simple_segment/logging'
+
 module SimpleSegment
   class Configuration
     include SimpleSegment::Utils
+    include SimpleSegment::Logging
 
-    attr_reader :write_key, :on_error
+    attr_reader :write_key, :on_error, :stub, :logger
 
     def initialize(settings = {})
       symbolized_settings = symbolize_keys(settings)
       @write_key = symbolized_settings[:write_key]
       @on_error = symbolized_settings[:on_error] || proc {}
+      @stub = symbolized_settings[:stub]
+      @logger = default_logger(symbolized_settings[:logger])
       raise ArgumentError, 'Missing required option :write_key' unless @write_key
     end
   end

--- a/lib/simple_segment/logging.rb
+++ b/lib/simple_segment/logging.rb
@@ -1,0 +1,16 @@
+require 'logger'
+module SimpleSegment
+  module Logging
+    def self.included(klass)
+      klass.extend(self)
+    end
+
+    def default_logger(logger_option)
+      if logger_option
+        logger_option
+      else
+        Logger.new STDOUT
+      end
+    end
+  end
+end

--- a/lib/simple_segment/request.rb
+++ b/lib/simple_segment/request.rb
@@ -6,27 +6,38 @@ module SimpleSegment
       'accept' => 'application/json'
     }.freeze
 
-    attr_reader :write_key, :error_handler
+    attr_reader :write_key, :error_handler, :stub, :logger
 
     def initialize(client)
       @write_key = client.config.write_key
       @error_handler = client.config.on_error
+      @stub = client.config.stub
+      @logger = client.config.logger
     end
 
     def post(path, payload, headers: DEFAULT_HEADERS)
-      response, status_code, response_body = nil, nil, nil
+      response = nil
+      status_code = nil
+      response_body = nil
       uri = URI(BASE_URL)
       payload = JSON.generate(payload)
+      if stub
+        logger.debug "stubbed request to \
+        #{path}: write key = #{write_key}, \
+        payload = #{payload}"
 
-      Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
-        request = Net::HTTP::Post.new(path, headers)
-        request.basic_auth write_key, nil
-        http.request(request, payload).tap { |res|
-          status_code = res.code
-          response_body = res.body
-          response = res
-          response.value
-        }
+        { status: 200, error: nil }
+      else
+        Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+          request = Net::HTTP::Post.new(path, headers)
+          request.basic_auth write_key, nil
+          http.request(request, payload).tap do |res|
+            status_code = res.code
+            response_body = res.body
+            response = res
+            response.value
+          end
+        end
       end
     rescue StandardError => e
       error_handler.call(status_code, response_body, e, response)

--- a/lib/simple_segment/version.rb
+++ b/lib/simple_segment/version.rb
@@ -1,3 +1,3 @@
 module SimpleSegment
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 end

--- a/spec/simple_segment/configuration_spec.rb
+++ b/spec/simple_segment/configuration_spec.rb
@@ -23,4 +23,17 @@ describe SimpleSegment::Configuration do
       expect(config.on_error).to be_a(Proc)
     end
   end
+
+  it 'works with stub' do
+    config = described_class.new(write_key: 'test', stub: true)
+    expect(config.stub).to eq true
+  end
+
+  it 'works with user prefered logging' do
+    config = described_class.new(
+      write_key: 'test',
+      logger: Logger.new(STDOUT)
+    )
+    expect(config.logger).not_to be_nil
+  end
 end

--- a/spec/simple_segment/operations/track_spec.rb
+++ b/spec/simple_segment/operations/track_spec.rb
@@ -33,5 +33,13 @@ describe SimpleSegment::Operations::Track do
         ).build_payload
       }.to raise_error(ArgumentError)
     end
+
+    it 'works with stubed calls' do
+      stubed_client = SimpleSegment::Client.new(write_key: 'key', stub: true)
+      expect(stubed_client.track(
+        event: 'event',
+        user_id: 'id'
+      )[:status]).to eq(200)
+    end
   end
 end


### PR DESCRIPTION
This is related to ticket #12 and #4 

- Added option to stub api calls like the official gem.
- Added option to configure the logger that want to be used keeping Ruby Logger class as default if none is set.