### PR TITLE
Update readme on_error argument order

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Create a client instance:
 ```ruby
 analytics = SimpleSegment::Client.new({
   write_key: 'YOUR_WRITE_KEY', # required
-  on_error: proc { |error_code, error_body, response, exception|
+  on_error: proc { |error_code, error_body, exception, response|
     # defaults to an empty proc
   }
 })


### PR DESCRIPTION
Looking at the implementation for the calling of the error handler:

```
error_handler.call(status_code, response_body, e, response)
```

It seems the exception is the third argument and not the forth.