### PR TITLE
Bug/isoify dates

### DIFF
--- a/lib/simple_segment/operations/group.rb
+++ b/lib/simple_segment/operations/group.rb
@@ -1,8 +1,6 @@
 module SimpleSegment
   module Operations
     class Group < Operation
-      include SimpleSegment::Utils
-
       def call
         request.post('/v1/group', build_payload)
       end

--- a/lib/simple_segment/operations/group.rb
+++ b/lib/simple_segment/operations/group.rb
@@ -1,6 +1,8 @@
 module SimpleSegment
   module Operations
     class Group < Operation
+      include SimpleSegment::Utils
+
       def call
         request.post('/v1/group', build_payload)
       end
@@ -10,7 +12,7 @@ module SimpleSegment
           unless options[:group_id]
 
         base_payload.merge(
-          traits: options[:traits],
+          traits: options[:traits] && isoify_dates!(options[:traits]),
           groupId: options[:group_id]
         )
       end

--- a/lib/simple_segment/operations/identify.rb
+++ b/lib/simple_segment/operations/identify.rb
@@ -1,8 +1,6 @@
 module SimpleSegment
   module Operations
     class Identify < Operation
-      include SimpleSegment::Utils
-
       def call
         request.post('/v1/identify', build_payload)
       end

--- a/lib/simple_segment/operations/identify.rb
+++ b/lib/simple_segment/operations/identify.rb
@@ -1,13 +1,15 @@
 module SimpleSegment
   module Operations
     class Identify < Operation
+      include SimpleSegment::Utils
+
       def call
         request.post('/v1/identify', build_payload)
       end
 
       def build_payload
         base_payload.merge(
-          traits: options[:traits]
+          traits: options[:traits] && isoify_dates!(options[:traits])
         )
       end
     end

--- a/lib/simple_segment/operations/operation.rb
+++ b/lib/simple_segment/operations/operation.rb
@@ -1,6 +1,8 @@
 module SimpleSegment
   module Operations
     class Operation
+      include SimpleSegment::Utils
+
       DEFAULT_CONTEXT = {
         library: {
           name: 'simple_segment',

--- a/lib/simple_segment/operations/page.rb
+++ b/lib/simple_segment/operations/page.rb
@@ -6,9 +6,11 @@ module SimpleSegment
       end
 
       def build_payload
+        properties = options[:properties] && isoify_dates!(options[:properties])
+
         base_payload.merge(
           name: options[:name],
-          properties: options[:properties]
+          properties: properties
         )
       end
     end

--- a/lib/simple_segment/operations/track.rb
+++ b/lib/simple_segment/operations/track.rb
@@ -11,7 +11,7 @@ module SimpleSegment
 
         base_payload.merge(
           event: options[:event],
-          properties: options[:properties]
+          properties: options[:properties] && isoify_dates!(options[:properties])
         )
       end
     end

--- a/lib/simple_segment/operations/track.rb
+++ b/lib/simple_segment/operations/track.rb
@@ -9,9 +9,11 @@ module SimpleSegment
         raise ArgumentError, 'event name must be present' \
           unless options[:event]
 
+        properties = options[:properties] && isoify_dates!(options[:properties])
+
         base_payload.merge(
           event: options[:event],
-          properties: options[:properties] && isoify_dates!(options[:properties])
+          properties: properties
         )
       end
     end

--- a/lib/simple_segment/utils.rb
+++ b/lib/simple_segment/utils.rb
@@ -9,5 +9,33 @@ module SimpleSegment
         result[key.to_sym] = value
       end
     end
+
+    # public: Converts all the date values in the into iso8601 strings in place
+    #
+    def isoify_dates!(hash)
+      hash.replace isoify_dates hash
+    end
+
+    # public: Returns a new hash with all the date values in the into iso8601
+    #         strings
+    #
+    def isoify_dates(hash)
+      hash.each_with_object({}) do |(k, v), memo|
+        memo[k] = maybe_datetime_in_iso8601(v)
+      end
+    end
+
+    def maybe_datetime_in_iso8601(prop)
+      case prop
+      when Time
+        prop.iso8601(3)
+      when DateTime
+        prop.to_time.iso8601(3)
+      when Date
+        prop.strftime('%F')
+      else
+        prop
+      end
+    end
   end
 end

--- a/spec/simple_segment/client_spec.rb
+++ b/spec/simple_segment/client_spec.rb
@@ -8,11 +8,18 @@ describe SimpleSegment::Client do
 
   describe '#identify' do
     it 'sends identity and properties to segment' do
+      time = Time.utc(2018, 3, 11, 10, 20)
+      dt = DateTime.new(2018, 3, 11, 12, 20) # rubocop:disable Style/DateTime
+      date = Date.new(2018, 3, 12)
+
       options = {
         user_id: 'id',
         traits: {
           name: 'Philip J. Fry',
-          occupation: 'Delivery Boy'
+          occupation: 'Delivery Boy',
+          foo_time: time,
+          foo_date_time: dt,
+          foo_date: date
         },
         context: {
           employer: 'Planet Express'
@@ -27,7 +34,10 @@ describe SimpleSegment::Client do
         'anonymousId' => nil,
         'traits' => {
           'name' => 'Philip J. Fry',
-          'occupation' => 'Delivery Boy'
+          'occupation' => 'Delivery Boy',
+          'foo_time' => '2018-03-11T10:20:00.000Z',
+          'foo_date_time' => dt.to_time.iso8601(3),
+          'foo_date' => '2018-03-12'
         },
         'context' => {
           'employer' => 'Planet Express',

--- a/spec/simple_segment/client_spec.rb
+++ b/spec/simple_segment/client_spec.rb
@@ -89,12 +89,19 @@ describe SimpleSegment::Client do
 
   describe '#track' do
     it 'sends event and properties to segment' do
+      time = Time.utc(2018, 3, 11, 10, 20)
+      dt = DateTime.new(2018, 3, 11, 12, 20) # rubocop:disable Style/DateTime
+      date = Date.new(2018, 3, 12)
+
       options = {
         event: 'Delivered Package',
         user_id: 'id',
         properties: {
           contents: 'Lug nuts',
-          delivery_to: 'Robots of Chapek 9'
+          delivery_to: 'Robots of Chapek 9',
+          foo_time: time,
+          foo_date_time: dt,
+          foo_date: date
         },
         context: {
           crew: %w(Bender Fry Leela)
@@ -110,7 +117,10 @@ describe SimpleSegment::Client do
         'anonymousId' => nil,
         'properties' => {
           'contents' => 'Lug nuts',
-          'delivery_to' => 'Robots of Chapek 9'
+          'delivery_to' => 'Robots of Chapek 9',
+          'foo_time' => '2018-03-11T10:20:00.000Z',
+          'foo_date_time' => dt.to_time.iso8601(3),
+          'foo_date' => '2018-03-12'
         },
         'context' => {
           'crew' => %w(Bender Fry Leela),

--- a/spec/simple_segment/client_spec.rb
+++ b/spec/simple_segment/client_spec.rb
@@ -167,11 +167,18 @@ describe SimpleSegment::Client do
 
   describe '#page' do
     it 'sends page info to segment' do
+      time = Time.utc(2018, 3, 11, 10, 20)
+      dt = DateTime.new(2018, 3, 11, 12, 20) # rubocop:disable Style/DateTime
+      date = Date.new(2018, 3, 12)
+
       options = {
         user_id: 'id',
         name: 'Zoidberg',
         properties: {
-          url: 'https://en.wikipedia.org/wiki/Zoidberg'
+          url: 'https://en.wikipedia.org/wiki/Zoidberg',
+          foo_time: time,
+          foo_date_time: dt,
+          foo_date: date
         },
         context: {
           company: 'Planet Express'
@@ -186,7 +193,10 @@ describe SimpleSegment::Client do
         'anonymousId' => nil,
         'name' => 'Zoidberg',
         'properties' => {
-          'url' => 'https://en.wikipedia.org/wiki/Zoidberg'
+          'url' => 'https://en.wikipedia.org/wiki/Zoidberg',
+          'foo_time' => '2018-03-11T10:20:00.000Z',
+          'foo_date_time' => dt.to_time.iso8601(3),
+          'foo_date' => '2018-03-12'
         },
         'context' => {
           'company' => 'Planet Express',

--- a/spec/simple_segment/client_spec.rb
+++ b/spec/simple_segment/client_spec.rb
@@ -219,11 +219,18 @@ describe SimpleSegment::Client do
 
   describe '#group' do
     it 'sends group info to segment' do
+      time = Time.utc(2018, 3, 11, 10, 20)
+      dt = DateTime.new(2018, 3, 11, 12, 20) # rubocop:disable Style/DateTime
+      date = Date.new(2018, 3, 12)
+
       options = {
         user_id: 'id',
         group_id: 'group_id',
         traits: {
-          name: 'Planet Express'
+          name: 'Planet Express',
+          foo_time: time,
+          foo_date_time: dt,
+          foo_date: date
         },
         context: {
           locale: 'AL1'
@@ -238,7 +245,10 @@ describe SimpleSegment::Client do
         'anonymousId' => nil,
         'groupId' => 'group_id',
         'traits' => {
-          'name' => 'Planet Express'
+          'name' => 'Planet Express',
+          'foo_time' => '2018-03-11T10:20:00.000Z',
+          'foo_date_time' => dt.to_time.iso8601(3),
+          'foo_date' => '2018-03-12'
         },
         'context' => {
           'locale' => 'AL1',


### PR DESCRIPTION
`Hubspot` rejects `identify` requests when there is a `Datapicker` field type involved and the related attribute in the `traits` is `DateTime` formatted.

The official Segment library https://github.com/segmentio/analytics-ruby is already doing similar parsing [here](https://github.com/segmentio/analytics-ruby/blob/1c63a85fbbf45c0293c2b0a0e0fc4e26ba3bf2b3/lib/segment/analytics/client.rb#L82)