### PR TITLE
Add settings to configure timeout options

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,22 @@ analytics = SimpleSegment::Client.new(
 )
 ```
 
+### Set HTTP Options
+
+You can set options that are passed to `Net::HTTP.start`.
+
+```ruby
+analytics = SimpleSegment::Client.new(
+  write_key: 'YOUR_WRITE_KEY',
+  http_options: {
+    open_timeout: 42,
+    read_timeout: 42,
+    close_on_empty_response: true,
+    # ...
+  }
+)
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/simple_segment/configuration.rb
+++ b/lib/simple_segment/configuration.rb
@@ -5,7 +5,7 @@ module SimpleSegment
     include SimpleSegment::Utils
     include SimpleSegment::Logging
 
-    attr_reader :write_key, :on_error, :stub, :logger, :open_timeout, :read_timeout
+    attr_reader :write_key, :on_error, :stub, :logger, :http_options
 
     def initialize(settings = {})
       symbolized_settings = symbolize_keys(settings)
@@ -13,8 +13,7 @@ module SimpleSegment
       @on_error = symbolized_settings[:on_error] || proc {}
       @stub = symbolized_settings[:stub]
       @logger = default_logger(symbolized_settings[:logger])
-      @open_timeout = symbolized_settings[:open_timeout]
-      @read_timeout = symbolized_settings[:read_timeout]
+      @http_options = symbolized_settings[:http_options] || {}
       raise ArgumentError, 'Missing required option :write_key' \
         unless @write_key
     end

--- a/lib/simple_segment/configuration.rb
+++ b/lib/simple_segment/configuration.rb
@@ -5,7 +5,7 @@ module SimpleSegment
     include SimpleSegment::Utils
     include SimpleSegment::Logging
 
-    attr_reader :write_key, :on_error, :stub, :logger
+    attr_reader :write_key, :on_error, :stub, :logger, :open_timeout, :read_timeout
 
     def initialize(settings = {})
       symbolized_settings = symbolize_keys(settings)
@@ -13,6 +13,8 @@ module SimpleSegment
       @on_error = symbolized_settings[:on_error] || proc {}
       @stub = symbolized_settings[:stub]
       @logger = default_logger(symbolized_settings[:logger])
+      @open_timeout = symbolized_settings[:open_timeout]
+      @read_timeout = symbolized_settings[:read_timeout]
       raise ArgumentError, 'Missing required option :write_key' \
         unless @write_key
     end

--- a/lib/simple_segment/configuration.rb
+++ b/lib/simple_segment/configuration.rb
@@ -13,7 +13,8 @@ module SimpleSegment
       @on_error = symbolized_settings[:on_error] || proc {}
       @stub = symbolized_settings[:stub]
       @logger = default_logger(symbolized_settings[:logger])
-      @http_options = symbolized_settings[:http_options] || {}
+      @http_options = { use_ssl: true }
+                      .merge(symbolized_settings[:http_options] || {})
       raise ArgumentError, 'Missing required option :write_key' \
         unless @write_key
     end

--- a/lib/simple_segment/request.rb
+++ b/lib/simple_segment/request.rb
@@ -6,13 +6,15 @@ module SimpleSegment
       'accept' => 'application/json'
     }.freeze
 
-    attr_reader :write_key, :error_handler, :stub, :logger
+    attr_reader :write_key, :error_handler, :stub, :logger, :open_timeout, :read_timeout
 
     def initialize(client)
       @write_key = client.config.write_key
       @error_handler = client.config.on_error
       @stub = client.config.stub
       @logger = client.config.logger
+      @open_timeout = client.config.open_timeout
+      @read_timeout = client.config.read_timeout
     end
 
     def post(path, payload, headers: DEFAULT_HEADERS)
@@ -29,7 +31,11 @@ module SimpleSegment
 
         { status: 200, error: nil }
       else
-        Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+        options = {}
+        options[:use_ssl] = true
+        options[:open_timeout] = open_timeout if open_timeout
+        options[:read_timeout] = read_timeout if read_timeout
+        Net::HTTP.start(uri.host, uri.port, options) do |http|
           request = Net::HTTP::Post.new(path, headers)
           request.basic_auth write_key, nil
           http.request(request, payload).tap do |res|

--- a/lib/simple_segment/request.rb
+++ b/lib/simple_segment/request.rb
@@ -6,15 +6,14 @@ module SimpleSegment
       'accept' => 'application/json'
     }.freeze
 
-    attr_reader :write_key, :error_handler, :stub, :logger, :open_timeout, :read_timeout
+    attr_reader :write_key, :error_handler, :stub, :logger, :http_options
 
     def initialize(client)
       @write_key = client.config.write_key
       @error_handler = client.config.on_error
       @stub = client.config.stub
       @logger = client.config.logger
-      @open_timeout = client.config.open_timeout
-      @read_timeout = client.config.read_timeout
+      @http_options = client.config.http_options
     end
 
     def post(path, payload, headers: DEFAULT_HEADERS)
@@ -31,10 +30,7 @@ module SimpleSegment
 
         { status: 200, error: nil }
       else
-        options = {}
-        options[:use_ssl] = true
-        options[:open_timeout] = open_timeout if open_timeout
-        options[:read_timeout] = read_timeout if read_timeout
+        options = { use_ssl: true }.merge(http_options)
         Net::HTTP.start(uri.host, uri.port, options) do |http|
           request = Net::HTTP::Post.new(path, headers)
           request.basic_auth write_key, nil

--- a/lib/simple_segment/request.rb
+++ b/lib/simple_segment/request.rb
@@ -30,8 +30,7 @@ module SimpleSegment
 
         { status: 200, error: nil }
       else
-        options = { use_ssl: true }.merge(http_options)
-        Net::HTTP.start(uri.host, uri.port, options) do |http|
+        Net::HTTP.start(uri.host, uri.port, http_options) do |http|
           request = Net::HTTP::Post.new(path, headers)
           request.basic_auth write_key, nil
           http.request(request, payload).tap do |res|

--- a/spec/simple_segment/configuration_spec.rb
+++ b/spec/simple_segment/configuration_spec.rb
@@ -45,6 +45,6 @@ describe SimpleSegment::Configuration do
 
   it 'accepts an http_options' do
     config = described_class.new(write_key: 'test', http_options: { read_timeout: 42 })
-    expect(config.http_options).to eq(use_ssl: true, read_timeout: 42)
+    expect(config.http_options).to eq({ use_ssl: true, read_timeout: 42 })
   end
 end

--- a/spec/simple_segment/configuration_spec.rb
+++ b/spec/simple_segment/configuration_spec.rb
@@ -37,4 +37,14 @@ describe SimpleSegment::Configuration do
     )
     expect(config.logger).to eq(my_logger)
   end
+
+  it 'accepts an open_timeout' do
+    config = described_class.new(write_key: test, open_timeout: 42)
+    expect(config.open_timeout).to eq(42)
+  end
+
+  it 'accepts a read_timeout' do
+    config = described_class.new(write_key: test, read_timeout: 42)
+    expect(config.read_timeout).to eq(42)
+  end
 end

--- a/spec/simple_segment/configuration_spec.rb
+++ b/spec/simple_segment/configuration_spec.rb
@@ -25,7 +25,7 @@ describe SimpleSegment::Configuration do
 
     it 'has a default http_options' do
       config = described_class.new(write_key: 'test')
-      expect(config.http_options).to eq({})
+      expect(config.http_options).to eq({ use_ssl: true })
     end
   end
 
@@ -45,6 +45,6 @@ describe SimpleSegment::Configuration do
 
   it 'accepts an http_options' do
     config = described_class.new(write_key: 'test', http_options: { read_timeout: 42 })
-    expect(config.http_options).to eq(read_timeout: 42)
+    expect(config.http_options).to eq(use_ssl: true, read_timeout: 42)
   end
 end

--- a/spec/simple_segment/configuration_spec.rb
+++ b/spec/simple_segment/configuration_spec.rb
@@ -39,12 +39,12 @@ describe SimpleSegment::Configuration do
   end
 
   it 'accepts an open_timeout' do
-    config = described_class.new(write_key: test, open_timeout: 42)
+    config = described_class.new(write_key: 'test', open_timeout: 42)
     expect(config.open_timeout).to eq(42)
   end
 
   it 'accepts a read_timeout' do
-    config = described_class.new(write_key: test, read_timeout: 42)
+    config = described_class.new(write_key: 'test', read_timeout: 42)
     expect(config.read_timeout).to eq(42)
   end
 end

--- a/spec/simple_segment/configuration_spec.rb
+++ b/spec/simple_segment/configuration_spec.rb
@@ -22,6 +22,11 @@ describe SimpleSegment::Configuration do
       config = described_class.new(write_key: 'test')
       expect(config.on_error).to be_a(Proc)
     end
+
+    it 'has a default http_options' do
+      config = described_class.new(write_key: 'test')
+      expect(config.http_options).to eq({})
+    end
   end
 
   it 'works with stub' do
@@ -38,13 +43,8 @@ describe SimpleSegment::Configuration do
     expect(config.logger).to eq(my_logger)
   end
 
-  it 'accepts an open_timeout' do
-    config = described_class.new(write_key: 'test', open_timeout: 42)
-    expect(config.open_timeout).to eq(42)
-  end
-
-  it 'accepts a read_timeout' do
-    config = described_class.new(write_key: 'test', read_timeout: 42)
-    expect(config.read_timeout).to eq(42)
+  it 'accepts an http_options' do
+    config = described_class.new(write_key: 'test', http_options: { read_timeout: 42 })
+    expect(config.http_options).to eq(read_timeout: 42)
   end
 end


### PR DESCRIPTION
Hello,

First of all thank you for this gem 🙏
We are using it at @TimelineInteractive to delay sending our event tracking using sidekiq.

We started to encounter some issues caused by timeouts of requests to segment. Since the ruby default timeout it 60 seconds, this caused serious delays in the processing of our queue.

We decided to fork the gem and configure the timeout options for the request.