### PR TITLE
Use an empty hash if no properties were provided to `track`

### DIFF
--- a/lib/simple_segment/operations/track.rb
+++ b/lib/simple_segment/operations/track.rb
@@ -8,14 +8,13 @@ module SimpleSegment
       end
 
       def build_payload
-        raise ArgumentError, 'event name must be present' \
-          unless options[:event]
+        raise ArgumentError, 'event name must be present' unless options[:event]
 
-        properties = options[:properties] && isoify_dates!(options[:properties])
+        properties = options[:properties] || {}
 
         base_payload.merge(
           event: options[:event],
-          properties: properties
+          properties: isoify_dates!(properties)
         )
       end
     end

--- a/spec/simple_segment/operations/track_spec.rb
+++ b/spec/simple_segment/operations/track_spec.rb
@@ -3,49 +3,61 @@
 require 'spec_helper'
 
 describe SimpleSegment::Operations::Track do
-  context 'timestamps' do
+  describe '#build_payload' do
     let(:client) { SimpleSegment::Client.new(write_key: 'key') }
 
-    it 'works with Time objects' do
+    it 'uses an empty hash if no properties were provided' do
       payload = described_class.new(
         client,
         event: 'event',
-        user_id: 'id',
-        timestamp: Time.new(2016, 6, 27, 23, 4, 20, '+03:00')
+        user_id: 'id'
       ).build_payload
 
-      expect(payload[:timestamp]).to eq('2016-06-27T23:04:20+03:00')
+      expect(payload[:properties]).to eq({})
     end
 
-    it 'works with iso8601 strings' do
-      payload = described_class.new(
-        client,
-        event: 'event',
-        user_id: 'id',
-        timestamp: '2016-06-27T20:04:20Z'
-      ).build_payload
-
-      expect(payload[:timestamp]).to eq('2016-06-27T20:04:20Z')
-    end
-
-    it 'errors with invalid strings' do
-      expect do
-        described_class.new(
+    context 'timestamps' do
+      it 'works with Time objects' do
+        payload = described_class.new(
           client,
           event: 'event',
           user_id: 'id',
-          timestamp: '2016 06 27T23:04:20'
+          timestamp: Time.new(2016, 6, 27, 23, 4, 20, '+03:00')
         ).build_payload
-      end.to raise_error(ArgumentError)
-    end
 
-    it 'works with stubed calls' do
-      stubed_client = SimpleSegment::Client.new(write_key: 'key', stub: true)
-      expect(stubed_client.track(
-        event: 'event',
-        user_id: 'id',
-        timestamp: Time.new(2016, 6, 27, 23, 4, 20, '+03:00')
-      )[:status]).to eq(200)
+        expect(payload[:timestamp]).to eq('2016-06-27T23:04:20+03:00')
+      end
+
+      it 'works with iso8601 strings' do
+        payload = described_class.new(
+          client,
+          event: 'event',
+          user_id: 'id',
+          timestamp: '2016-06-27T20:04:20Z'
+        ).build_payload
+
+        expect(payload[:timestamp]).to eq('2016-06-27T20:04:20Z')
+      end
+
+      it 'errors with invalid strings' do
+        expect do
+          described_class.new(
+            client,
+            event: 'event',
+            user_id: 'id',
+            timestamp: '2016 06 27T23:04:20'
+          ).build_payload
+        end.to raise_error(ArgumentError)
+      end
+
+      it 'works with stubed calls' do
+        stubed_client = SimpleSegment::Client.new(write_key: 'key', stub: true)
+        expect(stubed_client.track(
+          event: 'event',
+          user_id: 'id',
+          timestamp: Time.new(2016, 6, 27, 23, 4, 20, '+03:00')
+        )[:status]).to eq(200)
+      end
     end
   end
 end


### PR DESCRIPTION
We were sending `nil`, which Segment considers invalid. The official gem uses the same logic: https://github.com/segmentio/analytics-ruby/blob/8b87679c26af32bc60e5b20713c8af89e7316632/lib/segment/analytics/field_parser.rb#L18


Closes #27