### PR TITLE
add host option to support regional segments

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,17 @@ analytics = SimpleSegment::Client.new(
 )
 ```
 
+### Configurable Host
+
+You can use [regional segments](https://segment.com/docs/guides/regional-segment/) and send data to the desired region by setting the `host` parameter.
+
+```ruby
+analytics = SimpleSegment::Client.new(
+  write_key: 'YOUR_WRITE_KEY',
+  host: 'events.eu1.segmentapis.com'
+)
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/simple_segment/configuration.rb
+++ b/lib/simple_segment/configuration.rb
@@ -7,7 +7,9 @@ module SimpleSegment
     include SimpleSegment::Utils
     include SimpleSegment::Logging
 
-    attr_reader :write_key, :on_error, :stub, :logger, :http_options
+    DEFAULT_HOST = 'api.segment.io'
+
+    attr_reader :write_key, :on_error, :stub, :logger, :http_options, :host
 
     def initialize(settings = {})
       symbolized_settings = symbolize_keys(settings)
@@ -17,6 +19,7 @@ module SimpleSegment
       @logger = default_logger(symbolized_settings[:logger])
       @http_options = { use_ssl: true }
                       .merge(symbolized_settings[:http_options] || {})
+      @host = symbolized_settings[:host] || DEFAULT_HOST
       raise ArgumentError, 'Missing required option :write_key' \
         unless @write_key
     end

--- a/lib/simple_segment/request.rb
+++ b/lib/simple_segment/request.rb
@@ -2,13 +2,12 @@
 
 module SimpleSegment
   class Request
-    BASE_URL = 'https://api.segment.io'
     DEFAULT_HEADERS = {
       'Content-Type' => 'application/json',
       'accept' => 'application/json'
     }.freeze
 
-    attr_reader :write_key, :error_handler, :stub, :logger, :http_options
+    attr_reader :write_key, :error_handler, :stub, :logger, :http_options, :host
 
     def initialize(client)
       @write_key = client.config.write_key
@@ -16,6 +15,7 @@ module SimpleSegment
       @stub = client.config.stub
       @logger = client.config.logger
       @http_options = client.config.http_options
+      @host = client.config.host
     end
 
     def post(path, payload, headers: DEFAULT_HEADERS) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
@@ -23,17 +23,17 @@ module SimpleSegment
       status_code = nil
       response_body = nil
 
-      uri = URI(BASE_URL)
+      uri = URI("https://#{host}#{path}")
       payload = JSON.generate(payload)
       if stub
         logger.debug "stubbed request to \
-        #{path}: write key = #{write_key}, \
+        #{uri.path}: write key = #{write_key}, \
         payload = #{payload}"
 
         { status: 200, error: nil }
       else
         Net::HTTP.start(uri.host, uri.port, :ENV, http_options) do |http|
-          request = Net::HTTP::Post.new(path, headers)
+          request = Net::HTTP::Post.new(uri.path, headers)
           request.basic_auth write_key, nil
           http.request(request, payload).tap do |res|
             status_code = res.code

--- a/spec/simple_segment/configuration_spec.rb
+++ b/spec/simple_segment/configuration_spec.rb
@@ -29,6 +29,11 @@ describe SimpleSegment::Configuration do
       config = described_class.new(write_key: 'test')
       expect(config.http_options).to eq(use_ssl: true)
     end
+
+    it 'has a default host' do
+      config = described_class.new(write_key: 'test')
+      expect(config.host).to eq('api.segment.io')
+    end
   end
 
   it 'works with stub' do
@@ -48,5 +53,10 @@ describe SimpleSegment::Configuration do
   it 'accepts an http_options' do
     config = described_class.new(write_key: 'test', http_options: { read_timeout: 42 })
     expect(config.http_options).to eq(use_ssl: true, read_timeout: 42)
+  end
+
+  it 'accepts a host' do
+    config = described_class.new(write_key: 'test', host: 'events.eu1.segmentapis.com')
+    expect(config.host).to eq('events.eu1.segmentapis.com')
   end
 end

--- a/spec/simple_segment/request_spec.rb
+++ b/spec/simple_segment/request_spec.rb
@@ -40,4 +40,20 @@ describe SimpleSegment::Request do
       expect(exception).to be_a(Net::HTTPInternalServerError)
     end
   end
+
+  context 'with custom host' do
+    it 'uses configured host' do
+      request_stub = stub_request(:post, 'https://events.eu1.segmentapis.com/v1/track')
+                     .with(basic_auth: ['key', ''])
+                     .to_return(status: 200)
+
+      client = SimpleSegment::Client.new(
+        write_key: 'key',
+        host: 'events.eu1.segmentapis.com'
+      )
+      described_class.new(client).post('/v1/track', {})
+
+      expect(request_stub).to have_been_requested.once
+    end
+  end
 end


### PR DESCRIPTION
The `BASE_URL` is currently hard-coded to use `api.segment.io`, which is Segment’s US endpoint. In order to take advantage of Segment’s regional segments in EU the `host` needs to be customized to point to the EU host `events.eu1.segmentapis.com`.

Documentation for regional segments:
https://segment.com/docs/guides/regional-segment/

I considered following the `host` parameter format from the `analytics-ruby` gem, where it includes the `/v1` prefix, but I was concerned that it would be a breaking change if clients used `SimpleSegment::Request` directly.