### PR TITLE
update timecop to be compatible with Ruby 3.1

### DIFF
--- a/simple_segment.gemspec
+++ b/simple_segment.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '>= 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '1.23.0'
-  spec.add_development_dependency 'timecop', '~> 0.8.0'
+  spec.add_development_dependency 'timecop', '~> 0.9.5'
   spec.add_development_dependency 'webmock', '~> 3.7'
   spec.metadata = {
     'rubygems_mfa_required' => 'true'


### PR DESCRIPTION
I noticed in https://github.com/whatthewhat/simple_segment/pull/37 that the [ruby 3 check was failing](https://github.com/whatthewhat/simple_segment/runs/8092557921?check_suite_focus=true) with this error message:

```
Run bundle exec rake
/opt/hostedtoolcache/Ruby/3.1.2/x6[4](https://github.com/whatthewhat/simple_segment/runs/8092557921?check_suite_focus=true#step:4:5)/bin/ruby -I/home/runner/work/simple_segment/simple_segment/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib:/home/runner/work/simple_segment/simple_segment/vendor/bundle/ruby/3.1.0/gems/rspec-support-3.11.0/lib /home/runner/work/simple_segment/simple_segment/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
<internal:timev>:310:in `initialize': no implicit conversion of Hash into Integer (TypeError)
	from /home/runner/work/simple_segment/simple_segment/vendor/bundle/ruby/3.1.0/gems/timecop-0.8.1/lib/timecop/time_extensions.rb:22:in `new'
	from /home/runner/work/simple_segment/simple_segment/vendor/bundle/ruby/3.1.0/gems/timecop-0.8.1/lib/timecop/time_extensions.rb:22:in `new_with_mock_time'
	from <internal:timev>:224:in `now'
	from /home/runner/work/simple_segment/simple_segment/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/reporter.rb:89:in `start'
	from /home/runner/work/simple_segment/simple_segment/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/reporter.rb:72:in `report'
	from /home/runner/work/simple_segment/simple_segment/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:11[5](https://github.com/whatthewhat/simple_segment/runs/8092557921?check_suite_focus=true#step:4:6):in `run_specs'
	from /home/runner/work/simple_segment/simple_segment/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:89:in `run'
	from /home/runner/work/simple_segment/simple_segment/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:71:in `run'
	from /home/runner/work/simple_segment/simple_segment/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:45:in `invoke'
	from /home/runner/work/simple_segment/simple_segment/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/exe/rspec:4:in `<main>'
/opt/hostedtoolcache/Ruby/3.1.2/x[6](https://github.com/whatthewhat/simple_segment/runs/8092557921?check_suite_focus=true#step:4:7)4/bin/ruby -I/home/runner/work/simple_segment/simple_segment/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.[11](https://github.com/whatthewhat/simple_segment/runs/8092557921?check_suite_focus=true#step:4:12).0/lib:/home/runner/work/simple_segment/simple_segment/vendor/bundle/ruby/3.1.0/gems/rspec-support-3.11.0/lib /home/runner/work/simple_segment/simple_segment/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.11.0/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb failed
Error: Process completed with exit code 1.
```

It looks like `timecop` [added Ruby 3.1 support in version 0.9.4](https://github.com/travisjeffery/timecop/blob/master/History.md#v094). Updated to the latest version to fix the Ruby 3 CI run.