### PR TITLE
Update deprecated batching call to /v1/batch

### DIFF
--- a/lib/simple_segment/batch.rb
+++ b/lib/simple_segment/batch.rb
@@ -48,7 +48,7 @@ module SimpleSegment
         raise ArgumentError, 'A batch must contain at least one action'
       end
 
-      Request.new(client).post('/v1/import', payload)
+      Request.new(client).post('/v1/batch', payload)
     end
 
     private
@@ -56,7 +56,7 @@ module SimpleSegment
     def add(operation_class, options, action)
       operation = operation_class.new(client, symbolize_keys(options))
       operation_payload = operation.build_payload
-      operation_payload[:action] = action
+      operation_payload[:type] = action
       payload[:batch] << operation_payload
     end
   end

--- a/spec/simple_segment/batch_spec.rb
+++ b/spec/simple_segment/batch_spec.rb
@@ -6,11 +6,11 @@ describe SimpleSegment::Batch do
   let(:client) { SimpleSegment::Client.new(write_key: 'key') }
 
   it 'supports identify, group, track and page' do
-    request_stub = stub_request(:post, 'https://api.segment.io/v1/import')
+    request_stub = stub_request(:post, 'https://api.segment.io/v1/batch')
                    .with do |request|
                      batch = JSON.parse(request.body)['batch']
                      batch.map do |operation|
-                       operation['action']
+                       operation['type']
                      end == %w[identify group track page]
                    end
 
@@ -29,7 +29,7 @@ describe SimpleSegment::Batch do
 
   it 'allows to set common context' do
     expected_context = { 'foo' => 'bar' }
-    request_stub = stub_request(:post, 'https://api.segment.io/v1/import')
+    request_stub = stub_request(:post, 'https://api.segment.io/v1/batch')
                    .with do |request|
                      context = JSON.parse(request.body)['context']
                      context == expected_context
@@ -45,7 +45,7 @@ describe SimpleSegment::Batch do
 
   it 'allows to set common integrations' do
     expected_integrations = { 'foo' => 'bar' }
-    request_stub = stub_request(:post, 'https://api.segment.io/v1/import')
+    request_stub = stub_request(:post, 'https://api.segment.io/v1/batch')
                    .with do |request|
                      integrations = JSON.parse(request.body)['integrations']
                      integrations == expected_integrations
@@ -72,11 +72,11 @@ describe SimpleSegment::Batch do
   end
 
   it 'can be serialized and deserialized' do
-    request_stub = stub_request(:post, 'https://api.segment.io/v1/import')
+    request_stub = stub_request(:post, 'https://api.segment.io/v1/batch')
                    .with do |request|
                      batch = JSON.parse(request.body)['batch']
                      batch.map do |operation|
-                       operation['action']
+                       operation['type']
                      end == %w[identify track]
                    end
 

--- a/spec/simple_segment/client_spec.rb
+++ b/spec/simple_segment/client_spec.rb
@@ -394,7 +394,7 @@ describe SimpleSegment::Client do
 
   describe '#batch' do
     it 'batches events into a single request' do
-      request_stub = stub_request(:post, 'https://api.segment.io/v1/import')
+      request_stub = stub_request(:post, 'https://api.segment.io/v1/batch')
                      .with do |request|
                        JSON.parse(request.body)['batch'].length == 2
                      end


### PR DESCRIPTION
Description of changes:
I've updated the batch call from `/v1/import` to `/v1/batch` as noted in the issue [here](https://github.com/whatthewhat/simple_segment/issues/21).

As part of this migration the parameter "action" was also updated to "type". I've also fixed the existing tests for this.